### PR TITLE
feat: serve actionhero instance from the process cwd

### DIFF
--- a/actions/ah-swagger-plugin.js
+++ b/actions/ah-swagger-plugin.js
@@ -1,5 +1,9 @@
 'use strict'
-const { api, Action } = require('actionhero')
+const directoriesToSearch = [process.cwd()]
+const actionHeroInstanceIndexPath = require.resolve('actionhero', {
+  paths: directoriesToSearch
+})
+const { api, Action } = require(actionHeroInstanceIndexPath)
 
 module.exports = class SwaggerAction extends Action {
   constructor () {

--- a/initializers/ah-swagger-plugin.js
+++ b/initializers/ah-swagger-plugin.js
@@ -1,6 +1,9 @@
 'use strict'
-
-const { Initializer, api } = require('actionhero')
+const directoriesToSearch = [process.cwd()]
+const actionHeroInstanceIndexPath = require.resolve('actionhero', {
+  paths: directoriesToSearch
+})
+const { Initializer, api } = require(actionHeroInstanceIndexPath)
 
 module.exports = class SwaggerPlugin extends Initializer {
   constructor () {


### PR DESCRIPTION
The major issue that we were facing while developing `actionhero's plugins` was to develop and test the plugin at the same time, because of the way the `require` works in `nodeJs`. To test/develop plugins we need to have some `actionhero project` but while developing plugins we need to share the same instance of `actionhero` between plugin and the `actionhero project` which was an issue because the `plugin` and `actionhero project` did not share the same folder and `node_modules`

So to do that we had to move a bunch of folders & files manually / by script.

This solution presents a new way to solve that issue:
#### Previous way of including the `actionhero` package in plugins was:
```
require('actionhero')
```
Now by using `require.resolve` we can change the search pattern that is followed by require. 
See more about this [here](https://nodejs.org/api/modules.html#modules_require_resolve_request_options)

#### Proposed way of including the `actionhero` package in plugins:

```
const directoriesToSearch = [process.cwd()]
const actionHeroInstanceIndexPath = require.resolve('actionhero', {
  paths: directoriesToSearch
})
require(actionHeroInstanceIndexPath)

```
Now this will take the `actionhero` from the `node_modules` of the current process's `node_modules` which is exactly what we want.

Attaching some gifs to show how this is going to work :smile: 

